### PR TITLE
Removing "accept" header from cache/originRequest policy when AutoWebP is disabled.

### DIFF
--- a/source/constructs/lib/common-resources/common-resources-construct.ts
+++ b/source/constructs/lib/common-resources/common-resources-construct.ts
@@ -21,6 +21,7 @@ export interface Conditions {
   readonly enableSignatureCondition: CfnCondition;
   readonly enableDefaultFallbackImageCondition: CfnCondition;
   readonly enableCorsCondition: CfnCondition;
+  readonly enableAutoWebPCondition: CfnCondition;
 }
 
 export interface AppRegistryApplicationProps {
@@ -54,6 +55,9 @@ export class CommonResources extends Construct {
       }),
       enableCorsCondition: new CfnCondition(this, "EnableCorsCondition", {
         expression: Fn.conditionEquals(props.corsEnabled, "Yes"),
+      }),
+      enableAutoWebPCondition: new CfnCondition(this, "EnableAutoWebPCondition", {
+        expression: Fn.conditionEquals(props.autoWebP, "Yes"),
       }),
     };
 

--- a/source/constructs/lib/serverless-image-stack.ts
+++ b/source/constructs/lib/serverless-image-stack.ts
@@ -177,6 +177,7 @@ export class ServerlessImageHandlerStack extends Stack {
       logsBucket: commonResources.logsBucket,
       uuid: commonResources.customResources.uuid,
       cloudFrontPriceClass: cloudFrontPriceClassParameter.valueAsString,
+      conditions: commonResources.conditions,
       ...solutionConstructProps,
     });
 

--- a/source/constructs/test/__snapshots__/constructs.test.ts.snap
+++ b/source/constructs/test/__snapshots__/constructs.test.ts.snap
@@ -11,6 +11,14 @@ exports[`Serverless Image Handler Stack Snapshot 1`] = `
         "Yes",
       ],
     },
+    "CommonResourcesEnableAutoWebPCondition68405A08": {
+      "Fn::Equals": [
+        {
+          "Ref": "AutoWebPParameter",
+        },
+        "Yes",
+      ],
+    },
     "CommonResourcesEnableCorsConditionA0615348": {
       "Fn::Equals": [
         {
@@ -398,10 +406,18 @@ exports[`Serverless Image Handler Stack Snapshot 1`] = `
             "EnableAcceptEncodingGzip": true,
             "HeadersConfig": {
               "HeaderBehavior": "whitelist",
-              "Headers": [
-                "origin",
-                "accept",
-              ],
+              "Headers": {
+                "Fn::If": [
+                  "CommonResourcesEnableAutoWebPCondition68405A08",
+                  [
+                    "origin",
+                    "accept",
+                  ],
+                  [
+                    "origin",
+                  ],
+                ],
+              },
             },
             "QueryStringsConfig": {
               "QueryStringBehavior": "whitelist",
@@ -1254,10 +1270,18 @@ exports[`Serverless Image Handler Stack Snapshot 1`] = `
           },
           "HeadersConfig": {
             "HeaderBehavior": "whitelist",
-            "Headers": [
-              "origin",
-              "accept",
-            ],
+            "Headers": {
+              "Fn::If": [
+                "CommonResourcesEnableAutoWebPCondition68405A08",
+                [
+                  "origin",
+                  "accept",
+                ],
+                [
+                  "origin",
+                ],
+              ],
+            },
           },
           "Name": {
             "Fn::Join": [


### PR DESCRIPTION
There's no need to include the `accept` http header in the cloudfront's cache key when `AutoWebP` is disabled.  
These changes will improve the cloudfront's cache hit ratio when `AutoWebP` is not used. Also stops sending unnecesary header (in such case) to origin (resizing backend).

**Issue #, if available:**

#304

**Description of changes:**

Infrastructure generation code was modified. Added a cloudformation's boolean condition (`CfnCondition`) based on `AutoWebPParameter` value, and evaluated it (using a cloudformation's `Fn::If` instrinsic function) inside cache/originRequest policy code.  
Had to switch to "Cfn", aka L1, versions of cache/originRequest policy. Please read this [issue](https://github.com/aws/aws-cdk/issues/8396#issuecomment-857690411).  
  
Tests were updated to reflect changes.

**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
