### PR TITLE
validate image resize dimensions

### DIFF
--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -173,6 +173,13 @@ export class ImageHandler {
     } else {
       if (edits.resize.width) edits.resize.width = Math.round(Number(edits.resize.width));
       if (edits.resize.height) edits.resize.height = Math.round(Number(edits.resize.height));
+      if (edits.resize.width < 1 || edits.resize.height < 1) {
+        throw new ImageHandlerError(
+          StatusCodes.BAD_REQUEST,
+          "InvalidImageSizeException",
+          "The image size is invalid."
+        );
+      }
 
       if (edits.resize.ratio) {
         const ratio = edits.resize.ratio;

--- a/source/image-handler/test/image-handler/resize.spec.ts
+++ b/source/image-handler/test/image-handler/resize.spec.ts
@@ -6,7 +6,7 @@ import S3 from "aws-sdk/clients/s3";
 import sharp from "sharp";
 
 import { ImageHandler } from "../../image-handler";
-import { ImageEdits } from "../../lib";
+import { ImageEdits, ImageHandlerError } from "../../lib";
 
 const s3Client = new S3();
 const rekognitionClient = new Rekognition();
@@ -32,5 +32,23 @@ describe("resize", () => {
       .resize({ width: 99, height: 100 })
       .toBuffer();
     expect(resultBuffer).toEqual(convertedImage);
+  });
+
+
+  it("Should throw an error if image edits dimensions are invalid", async () => {
+    // Arrange
+    const originalImage = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+      "base64"
+    );
+    const image = sharp(originalImage, { failOnError: false }).withMetadata();
+    const edits: ImageEdits = { resize: { width: 0, height: 0 } };
+
+    // Act
+    const imageHandler = new ImageHandler(s3Client, rekognitionClient);
+
+    // Assert
+    await expect(imageHandler.applyEdits(image, edits, false)).rejects.toThrow(ImageHandlerError);
+
   });
 });


### PR DESCRIPTION
**Issue #, if available:** -


**Description of changes:**
Clients who request invalid image resize dimensions should get a 4xx error rather than a 5xx


**Checklist**
- [x] :wave: I have added unit tests for all code changes.
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
