### PR TITLE
Fix large pixel image rendition issue by adding limitInputPixels option

### DIFF
--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -76,7 +76,11 @@ export class ImageHandler {
    */
   async process(imageRequestInfo: ImageRequestInfo): Promise<string> {
     const { originalImage, edits } = imageRequestInfo;
-    const options = { failOnError: false, limitInputPixels: false, animated: imageRequestInfo.contentType === ContentTypes.GIF };
+    const options = {
+      failOnError: false,
+      limitInputPixels: false,
+      animated: imageRequestInfo.contentType === ContentTypes.GIF,
+    };
     let base64EncodedImage = "";
 
     // Apply edits if specified
@@ -87,8 +91,12 @@ export class ImageHandler {
       const metadata = await image.metadata();
       const pixel = metadata.width * metadata.height;
       // To avoid unwanted resource consumption, check and set the pixel limit to true for images with width and height less than 16364 * 16364. Reinstantiate the Image with low pixel limit.
-      if(pixel <= this.LARGE_IMAGE_SIZE){                     
-        const newoptions = { failOnError: false, limitInputPixels: true, animated: imageRequestInfo.contentType === ContentTypes.GIF };
+      if (pixel <= this.LARGE_IMAGE_SIZE) {
+        const newoptions = {
+          failOnError: false,
+          limitInputPixels: true,
+          animated: imageRequestInfo.contentType === ContentTypes.GIF,
+        };
         image = await this.instantiateSharpImage(originalImage, edits, newoptions);
       }
       // apply image edits

--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -86,7 +86,7 @@ export class ImageHandler {
       //Get source image metadata
       const metadata = await image.metadata();
       const pixel = metadata.width * metadata.height;
-      // To consume resources, check and set the limit if the image width is 16364 or less. Reinstantiate the Image with low pixel limit.
+      // To avoid unwanted resource consumption, check and set the pixel limit to true for images with width and height less than 16364 * 16364. Reinstantiate the Image with low pixel limit.
       if(pixel <= this.LARGE_IMAGE_SIZE){                     
         const newoptions = { failOnError: false, limitInputPixels: true, animated: imageRequestInfo.contentType === ContentTypes.GIF };
         image = await this.instantiateSharpImage(originalImage, edits, newoptions);

--- a/source/image-handler/test/image-handler/resize.spec.ts
+++ b/source/image-handler/test/image-handler/resize.spec.ts
@@ -4,45 +4,30 @@
 import Rekognition from "aws-sdk/clients/rekognition";
 import S3 from "aws-sdk/clients/s3";
 import sharp from "sharp";
-import fs from "fs";
-
 
 import { ImageHandler } from "../../image-handler";
 import { ImageEdits } from "../../lib";
 
 const s3Client = new S3();
 const rekognitionClient = new Rekognition();
-const LARGE_IMAGE_SIZE = 16364 * 16364;
 
 describe("resize", () => {
   it("Should pass if resize width and height are provided as string number to the function", async () => {
     // Arrange
-    //const originalImage = Buffer.from(
-    //  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
-    //  "base64"
-    //);
-    const originalImage = fs.readFileSync("./test/image/aws_logo.png");
-    let limitFlag = false;
-    let image = sharp(originalImage, { failOnError: false, limitInputPixels: limitFlag }).withMetadata();
-    //Get source image metadata
-    const metadata = await image.metadata();
-    const pixel = metadata.width * metadata.height;
-    console.log("Source Image Pixel  Size: " + pixel + " pixels");
-    // To avoid unwanted resource consumption, check and set the pixel limit to true for images with width and height less than 16364 * 16364.
-    // Reinstantiate the Image with low pixel limit.
-    if(pixel <= LARGE_IMAGE_SIZE){  
-      limitFlag = true                   
-      image = sharp(originalImage, { failOnError: false, limitInputPixels: limitFlag }).withMetadata();
-    }
+    const originalImage = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+      "base64"
+    );
+    const image = sharp(originalImage, { failOnError: false }).withMetadata();
     const edits: ImageEdits = { resize: { width: "99.1", height: "99.9" } };
-    console.log("Limit flag: " + limitFlag);
+
     // Act
     const imageHandler = new ImageHandler(s3Client, rekognitionClient);
     const result = await imageHandler.applyEdits(image, edits, false);
 
     // Assert
     const resultBuffer = await result.toBuffer();
-    const convertedImage = await sharp(originalImage, { failOnError: false, limitInputPixels: limitFlag })
+    const convertedImage = await sharp(originalImage, { failOnError: false })
       .withMetadata()
       .resize({ width: 99, height: 100 })
       .toBuffer();

--- a/source/image-handler/test/image-handler/resize.spec.ts
+++ b/source/image-handler/test/image-handler/resize.spec.ts
@@ -4,30 +4,45 @@
 import Rekognition from "aws-sdk/clients/rekognition";
 import S3 from "aws-sdk/clients/s3";
 import sharp from "sharp";
+import fs from "fs";
+
 
 import { ImageHandler } from "../../image-handler";
 import { ImageEdits } from "../../lib";
 
 const s3Client = new S3();
 const rekognitionClient = new Rekognition();
+const LARGE_IMAGE_SIZE = 16364 * 16364;
 
 describe("resize", () => {
   it("Should pass if resize width and height are provided as string number to the function", async () => {
     // Arrange
-    const originalImage = Buffer.from(
-      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
-      "base64"
-    );
-    const image = sharp(originalImage, { failOnError: false }).withMetadata();
+    //const originalImage = Buffer.from(
+    //  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+    //  "base64"
+    //);
+    const originalImage = fs.readFileSync("./test/image/aws_logo.png");
+    let limitFlag = false;
+    let image = sharp(originalImage, { failOnError: false, limitInputPixels: limitFlag }).withMetadata();
+    //Get source image metadata
+    const metadata = await image.metadata();
+    const pixel = metadata.width * metadata.height;
+    console.log("Source Image Pixel  Size: " + pixel + " pixels");
+    // To avoid unwanted resource consumption, check and set the pixel limit to true for images with width and height less than 16364 * 16364.
+    // Reinstantiate the Image with low pixel limit.
+    if(pixel <= LARGE_IMAGE_SIZE){  
+      limitFlag = true                   
+      image = sharp(originalImage, { failOnError: false, limitInputPixels: limitFlag }).withMetadata();
+    }
     const edits: ImageEdits = { resize: { width: "99.1", height: "99.9" } };
-
+    console.log("Limit flag: " + limitFlag);
     // Act
     const imageHandler = new ImageHandler(s3Client, rekognitionClient);
     const result = await imageHandler.applyEdits(image, edits, false);
 
     // Assert
     const resultBuffer = await result.toBuffer();
-    const convertedImage = await sharp(originalImage, { failOnError: false })
+    const convertedImage = await sharp(originalImage, { failOnError: false, limitInputPixels: limitFlag })
       .withMetadata()
       .resize({ width: 99, height: 100 })
       .toBuffer();

--- a/source/image-handler/test/image-handler/resizelimitpixel.spec.ts
+++ b/source/image-handler/test/image-handler/resizelimitpixel.spec.ts
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import Rekognition from "aws-sdk/clients/rekognition";
+import S3 from "aws-sdk/clients/s3";
+import sharp from "sharp";
+import fs from "fs";
+
+import { ImageHandler } from "../../image-handler";
+import { ImageEdits } from "../../lib";
+
+const s3Client = new S3();
+const rekognitionClient = new Rekognition();
+const LARGE_IMAGE_SIZE = 16364 * 16364;
+
+describe("resizelimitpixel", () => {
+  it("Should pass if resize width and height are provided as string number to the function", async () => {
+    const originalImage = fs.readFileSync("./test/image/aws_logo.png");
+    let limitFlag = false;
+    let image = sharp(originalImage, { failOnError: false, limitInputPixels: limitFlag }).withMetadata();
+    //Get source image metadata
+    const metadata = await image.metadata();
+    const pixel = metadata.width * metadata.height;
+    console.log("Source Image Pixel  Size: " + pixel + " pixels");
+    // To avoid unwanted resource consumption, check and set the pixel limit to true for images with width and height less than 16364 * 16364.
+    // Reinstantiate the Image with low pixel limit.
+    if (pixel <= LARGE_IMAGE_SIZE) {
+      limitFlag = true;
+      image = sharp(originalImage, { failOnError: false, limitInputPixels: limitFlag }).withMetadata();
+    }
+    const edits: ImageEdits = { resize: { width: "99.1", height: "99.9" } };
+    // Act
+    const imageHandler = new ImageHandler(s3Client, rekognitionClient);
+    const result = await imageHandler.applyEdits(image, edits, false);
+
+    // Assert
+    const resultBuffer = await result.toBuffer();
+    const convertedImage = await sharp(originalImage, { failOnError: false, limitInputPixels: limitFlag })
+      .withMetadata()
+      .resize({ width: 99, height: 100 })
+      .toBuffer();
+    expect(resultBuffer).toEqual(convertedImage);
+  });
+});


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws-solutions/serverless-image-handler/issues/465


**Description of changes:**
Implement limitInputPixels option which is now supported by sharp library. This will enable us to process very large images . Any image larger than 16364 * 16364 need limitInputPixels set to false.

**Checklist**
- [x] :wave: I have added unit tests for all code changes.
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
