### PR TITLE
Fix TypeError when processing SVG images with undefined edits

### DIFF
--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -137,7 +137,7 @@ export class ImageRequest {
        */
       if (
         imageRequestInfo.contentType !== ContentTypes.SVG ||
-        imageRequestInfo.edits.toFormat ||
+        imageRequestInfo.edits?.toFormat ||
         imageRequestInfo.outputFormat
       ) {
         this.determineOutputFormat(imageRequestInfo, event);


### PR DESCRIPTION
**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->
#604 


**Description of changes:**
<!-- Please describe the changes you made -->
When processing SVG images where imageRequestInfo.edits is undefined, the code was attempting to access edits.toFormat directly, causing a TypeError that crashed the image

  processing pipeline.
 - Fix TypeError when processing SVG images with undefined edits
 - Add optional chaining (?.) to safely access edits.toFormat property
 - Prevents "Cannot read properties of undefined (reading 'toFormat')" errors

**Checklist**
- [ ] :wave: I have added unit tests for all code changes.
- [ ] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
