### PR TITLE
Add support for device pixel ratio (dpr) in query parameter mapping

### DIFF
--- a/source/image-handler/cloudfront-function-handlers/apig-request-modifier.js
+++ b/source/image-handler/cloudfront-function-handlers/apig-request-modifier.js
@@ -16,7 +16,7 @@ function processQueryParams(querystring) {
         return [];
     }
 
-    const ALLOWED_PARAMS = ['signature', 'expires', 'format', 'fit', 'width', 'height', 'rotate', 'flip', 'flop', 'grayscale'];
+    const ALLOWED_PARAMS = ['signature', 'expires', 'format', 'fit', 'width', 'height', 'rotate', 'flip', 'flop', 'grayscale', 'dpr'];
     
     let qs = [];
     for (const key in querystring) {

--- a/source/image-handler/lib/interfaces.ts
+++ b/source/image-handler/lib/interfaces.ts
@@ -13,6 +13,7 @@ export interface QueryStringParameters {
   fit?: string;
   width?: string;
   height?: string;
+  dpr?: string;
   rotate?: string;
   flip?: string;
   flop?: string;

--- a/source/image-handler/query-param-mapper.ts
+++ b/source/image-handler/query-param-mapper.ts
@@ -21,7 +21,13 @@ export class QueryParamMapper {
     greyscale: { path: [], key: "greyscale", transform: stringToBoolean },
   };
 
-  public static readonly QUERY_PARAM_KEYS = Object.keys(this.QUERY_PARAM_MAPPING);
+  // dpr is handled separately from QUERY_PARAM_MAPPING because it scales the
+  // resize dimensions rather than mapping to its own edit key.
+  private static readonly DPR_PARAM = "dpr";
+
+  private static readonly MAX_DPR = 4;
+
+  public static readonly QUERY_PARAM_KEYS = [...Object.keys(this.QUERY_PARAM_MAPPING), this.DPR_PARAM];
 
   /**
    * Initializer function for creating a new Thumbor mapping, used by the image
@@ -55,6 +61,8 @@ export class QueryParamMapper {
         }
       });
 
+      this.applyDpr(result, queryParameters[QueryParamMapper.DPR_PARAM]);
+
       return result;
     } catch (error) {
       console.error(error);
@@ -63,6 +71,28 @@ export class QueryParamMapper {
         "QueryParameterParsingError",
         "Query parameter parsing failed"
       );
+    }
+  }
+
+  /**
+   * Scales the resize dimensions by the requested device pixel ratio.
+   * Invalid values (non-numeric, zero, or negative) are ignored; values above MAX_DPR are clamped.
+   * @param edits The edits object produced from the query parameters.
+   * @param dprValue The raw dpr query parameter value.
+   */
+  private applyDpr(edits: ImageEdits, dprValue?: string): void {
+    if (dprValue === undefined || !edits.resize) {
+      return;
+    }
+    const dpr = parseFloat(dprValue);
+    if (isNaN(dpr) || dpr <= 0) {
+      return;
+    }
+    const clampedDpr = Math.min(dpr, QueryParamMapper.MAX_DPR);
+    for (const dimension of ["width", "height"]) {
+      if (typeof edits.resize[dimension] === "number") {
+        edits.resize[dimension] = Math.round(edits.resize[dimension] * clampedDpr);
+      }
     }
   }
 }

--- a/source/image-handler/test/cloudfront-function-handlers/apig-request-modifier.spec.ts
+++ b/source/image-handler/test/cloudfront-function-handlers/apig-request-modifier.spec.ts
@@ -22,6 +22,11 @@ describe("index", () => {
         expected: "format=value3",
       },
       {
+        // dpr is an allowed param
+        input: { width: { value: "100" }, dpr: { value: "2" } },
+        expected: "dpr=2&width=100",
+      },
+      {
         // Multi value keys use the last option
         input: {
           signature: { value: "value1" },

--- a/source/image-handler/test/image-handler/query-param-mapper.spec.ts
+++ b/source/image-handler/test/image-handler/query-param-mapper.spec.ts
@@ -103,6 +103,85 @@ describe("QueryParamMapper", () => {
       });
     });
 
+    it("should scale width and height by dpr", () => {
+      const result = mapper.mapQueryParamsToEdits({
+        width: "100",
+        height: "200",
+        dpr: "2",
+      });
+      expect(result).toEqual({
+        resize: {
+          width: 200,
+          height: 400,
+        },
+      });
+    });
+
+    it("should support fractional dpr and round the result", () => {
+      const result = mapper.mapQueryParamsToEdits({
+        width: "101",
+        dpr: "1.5",
+      });
+      expect(result).toEqual({
+        resize: {
+          width: 152,
+        },
+      });
+    });
+
+    it("should support dpr values below 1", () => {
+      const result = mapper.mapQueryParamsToEdits({
+        width: "100",
+        dpr: "0.5",
+      });
+      expect(result).toEqual({
+        resize: {
+          width: 50,
+        },
+      });
+    });
+
+    it("should clamp dpr to a maximum of 4", () => {
+      const result = mapper.mapQueryParamsToEdits({
+        width: "100",
+        dpr: "10",
+      });
+      expect(result).toEqual({
+        resize: {
+          width: 400,
+        },
+      });
+    });
+
+    it("should ignore invalid dpr values", () => {
+      const nan = mapper.mapQueryParamsToEdits({ width: "100", dpr: "abc" });
+      const zero = mapper.mapQueryParamsToEdits({ width: "100", dpr: "0" });
+      const negative = mapper.mapQueryParamsToEdits({ width: "100", dpr: "-2" });
+
+      expect(nan).toEqual({ resize: { width: 100 } });
+      expect(zero).toEqual({ resize: { width: 100 } });
+      expect(negative).toEqual({ resize: { width: 100 } });
+    });
+
+    it("should ignore dpr when no resize dimensions are present", () => {
+      const result = mapper.mapQueryParamsToEdits({ dpr: "2" });
+      expect(result).toEqual({});
+    });
+
+    it("should not scale null dimensions with dpr", () => {
+      const result = mapper.mapQueryParamsToEdits({
+        width: "0",
+        height: "200",
+        dpr: "2",
+      });
+      expect(result).toEqual({
+        resize: {
+          width: null,
+          height: 400,
+        },
+      });
+    });
+
     it("should throw ImageHandlerError on parsing failure", () => {
       // Mock console.error to avoid logging during test
       console.error = jest.fn();
@@ -148,6 +227,7 @@ describe("QueryParamMapper", () => {
       expect(QueryParamMapper.QUERY_PARAM_KEYS).toContain("flip");
       expect(QueryParamMapper.QUERY_PARAM_KEYS).toContain("flop");
       expect(QueryParamMapper.QUERY_PARAM_KEYS).toContain("grayscale");
+      expect(QueryParamMapper.QUERY_PARAM_KEYS).toContain("dpr");
     });
   });
 });


### PR DESCRIPTION
- Introduced dpr as a new query parameter in QueryParamMapper to scale image dimensions.
- Updated ALLOWED_PARAMS in apig-request-modifier to include dpr.
- Enhanced QueryStringParameters interface to accommodate dpr.
- Added tests to validate dpr functionality, including scaling, clamping, and handling invalid values.

**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->



**Description of changes:**
<!-- Please describe the changes you made -->


**Checklist**
- [ ] :wave: I have added unit tests for all code changes.
- [ ] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
